### PR TITLE
Changed container display none to height 0 width 0

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -3,7 +3,9 @@
     var createSpriteElement = function (url, svgText) {
         var wrap            = document.createElement('span');
         wrap.innerHTML      = svgText;
-        wrap.style.display  = 'none';
+        wrap.style.display  = 'block';
+        wrap.style.height   = 0;
+        wrap.style.width    = 0;
 
         // append
         document.body.insertBefore(wrap, document.body.firstChild);


### PR DESCRIPTION
I've discovered a situation with all modern browsers where SVG gradients will not work if their element (the `<linearGradient>` or `<radialGradient>`, etc) is within an SVG that is `display: none;` (or if their parents are `display: none;`). The gradient will simply not show up. I'm not sure if this is a bug with all browsers or if this is part of how SVGs are supposed to work. I can't find any information on this discovery so far.

This change adjusts the span container to instead display block but make it width 0, height 0, which should keep it hidden still, but it will keep gradients from breaking when used.
